### PR TITLE
Upgrade from old Debian stretch  to bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 
 WORKDIR /webdis
 COPY webdis ./src


### PR DESCRIPTION
Debian Stretch had an [EOL of June 30, 2022](https://wiki.debian.org/LTS).

This PR upgrades the Debian version being used to the Debian 11 Bullseye release.